### PR TITLE
Allow specification of isolation module.

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -22,6 +22,7 @@ function slave {
   [[ ! ${ULIMIT:-} ]] || ulimit $ULIMIT
   [[ ! ${MASTER:-} ]] || args+=( --master="$MASTER" )
   [[ ! ${LOGS:-} ]]   || args+=( --log_dir="$LOGS" )
+  [[ ! ${ISOLATION:-} ]] || args+=( --isolation="$ISOLATION" )
   logged /usr/local/sbin/mesos-slave "${args[@]}"
 }
 


### PR DESCRIPTION
Allow mesos-init-wrapper to respect an isolation module specified in /etc/default/mesos-slave.
