### PR TITLE
Adjust build jobs based on cores available.

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -76,7 +76,8 @@ function build {(
   mkdir -p build
   cd build
   ../configure
-  make -j 16
+  # optimal number of build jobs is 2x num_cores
+  make -j $(($(num_cores)*2))
 )}
 
 function os_release {
@@ -270,6 +271,23 @@ function url_split {
   out "$fragment"
 }
 
+# Print the number of cores detected. If we are unable to determine the number
+# of cores, print a warning and assume "1" core.
+function num_cores {
+  local cores=
+  if hash nproc 2>/dev/null; then
+    # Linux based systems
+    cores=$(nproc)
+  elif hash sysctl 2>/dev/null && [[ "$(os_release)" = "macosx/10" ]]; then
+    # OSX
+    cores=$(sysctl -n hw.ncpu)
+  else
+    err "Could not determine the number of cores, defaulting to 1 core."
+    cores=1
+  fi
+  out "$cores"
+}
+
 function msg { out "$*" >&2 ;}
 function err { local x=$? ; msg "$*" ; return $(( $x == 0 ? 1 : $x )) ;}
 function out { printf '%s\n' "$*" ;}
@@ -285,4 +303,3 @@ else
   get_system_info
   main "$@"
 fi
-

--- a/ubuntu/master.upstart
+++ b/ubuntu/master.upstart
@@ -1,6 +1,10 @@
 description "mesos master"
 
-start on runlevel [2345]
+# Start just after the System-V jobs (rc) to ensure networking and zookeeper
+# are started. This is as simple as possible to ensure compatibility with
+# Ubuntu, Debian, CentOS, and RHEL distros. See:
+# http://upstart.ubuntu.com/cookbook/#standard-idioms
+start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec /usr/bin/mesos-init-wrapper master

--- a/ubuntu/slave.upstart
+++ b/ubuntu/slave.upstart
@@ -1,6 +1,10 @@
 description "mesos slave"
 
-start on runlevel [2345]
+# Start just after the System-V jobs (rc) to ensure networking and zookeeper
+# are started. This is as simple as possible to ensure compatibility with
+# Ubuntu, Debian, CentOS, and RHEL distros. See:
+# http://upstart.ubuntu.com/cookbook/#standard-idioms
+start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec /usr/bin/mesos-init-wrapper slave


### PR DESCRIPTION
Automatically set the number of build jobs (make -j) based on the
number of cores available. The optimal setting is generally 2x the
number of cores. If we set this to an arbitrarily large value, it
tends to degrade performance and may even exhaust available memory
on machines with less than 8GB of RAM.
