### PR TITLE
Without cxx11

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -75,7 +75,7 @@ function build {(
   ./bootstrap
   mkdir -p build
   cd build
-  ../configure
+  ../configure $(configure_opts)
   # optimal number of build jobs is 2x num_cores
   make -j $(($(num_cores)*2))
 )}
@@ -286,6 +286,15 @@ function num_cores {
     fi
   fi
   out "$cores"
+}
+
+# Return Mesos configuration options
+function configure_opts {
+  local options=
+  if [[ "$version" == 0.18.0-rc4 ]] || [[ "$repo" =~ 0\.18\.0-rc4$ ]]
+  then options="--without-cxx11"                # See: MESOS-750 and MESOS-1095
+  fi
+  out "$options"
 }
 
 function msg { out "$*" >&2 ;}

--- a/build_mesos
+++ b/build_mesos
@@ -76,7 +76,8 @@ function build {(
   mkdir -p build
   cd build
   ../configure
-  make -j 16
+  # optimal number of build jobs is 2x num_cores
+  make -j $(($(num_cores)*2))
 )}
 
 function os_release {
@@ -270,6 +271,23 @@ function url_split {
   out "$fragment"
 }
 
+# Print the number of cores detected. If we are unable to determine the number
+# of cores, print a warning and assume "1" core.
+function num_cores {
+  local cores=
+  if hash nproc 2>/dev/null; then
+    # Linux based systems
+    cores=$(nproc)
+  elif hash sysctl 2>/dev/null && [[ "$(os_release)" = "macosx/10" ]]; then
+    # OSX
+    cores=$(sysctl -n hw.ncpu)
+  else
+    err "Could not determine the number of cores, defaulting to 1 core."
+    cores=1
+  fi
+  out "$cores"
+}
+
 function msg { out "$*" >&2 ;}
 function err { local x=$? ; msg "$*" ; return $(( $x == 0 ? 1 : $x )) ;}
 function out { printf '%s\n' "$*" ;}
@@ -285,4 +303,3 @@ else
   get_system_info
   main "$@"
 fi
-

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -99,7 +99,6 @@ function slave {
     local formatted="$(printf ';%s' "${resources[@]}")"
     args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
   fi
-  ( logged /usr/local/sbin/mesos-slave --master="$MASTER" --recover=cleanup )
   logged /usr/local/sbin/mesos-slave "${args[@]}"
 }
 

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -7,6 +7,49 @@ cat <<USAGE
   Run Mesos in master or slave mode, loading environment files, setting up
   logging and loading config parameters as appropriate.
 
+  To configure Mesos, you have many options:
+
+ *  Set a Zookeeper URL in
+
+      /etc/mesos/zk
+
+    and it will be picked up by the slave and master.
+
+ *  You can set environment variables (including the MESOS_* variables) in
+    files under /etc/default/:
+
+      /etc/default/mesos          # For both slave and master.
+      /etc/default/mesos-master   # For the master only.
+      /etc/default/mesos-slave    # For the slave only.
+
+ *  To set command line options for the slave or master, you can create files
+    under certain directories:
+
+      /etc/mesos-slave            # For the slave only.
+      /etc/mesos-master           # For the master only.
+
+    For example, to set the port for the slave:
+
+      echo 5050 > /etc/mesos-slave/port
+
+    To set the switch user flag:
+
+      touch /etc/mesos-slave/?switch_user
+
+    To explicitly disable it:
+
+      touch /etc/mesos-slave/?no-switch_user
+
+    Adding attributes and resources to the slaves is slightly more granular.
+    Although you can pass them all at once with files called 'attributes' and
+    'resources', you can also set them by creating files under directories
+    labeled 'attributes' or 'resources':
+
+      echo north-west > /etc/mesos-slave/attributes/rack
+
+    This is intended to allow easy addition and removal of attributes and
+    resources from the slave configuration.
+
 USAGE
 }; function --help { -h ;}                 # A nice way to handle -h and --help
 export LC_ALL=en_US.UTF-8                    # A locale that works consistently
@@ -16,17 +59,52 @@ function main {
 }
 
 function slave {
+  local etc_slave=/etc/mesos-slave
   local args=()
+  local attributes=()
+  local resources=()
   [[ ! -f /etc/default/mesos ]]       || . /etc/default/mesos
   [[ ! -f /etc/default/mesos-slave ]] || . /etc/default/mesos-slave
   [[ ! ${ULIMIT:-} ]]    || ulimit $ULIMIT
   [[ ! ${MASTER:-} ]]    || args+=( --master="$MASTER" )
+  [[ ! ${IP:-} ]]        || args+=( --ip="$IP" )
   [[ ! ${LOGS:-} ]]      || args+=( --log_dir="$LOGS" )
   [[ ! ${ISOLATION:-} ]] || args+=( --isolation="$ISOLATION" )
+  for f in "$etc_slave"/* # attributes ip resources isolation &al.
+  do
+    if [[ -f $f ]]
+    then
+      local name="$(basename "$f")"
+      if [[ $name == '?'* ]]         # Recognize flags (options without values)
+      then args+=( --"$name" )
+      else args+=( --"$name"="$(cat "$f")" )
+      fi
+    fi
+  done
+  # We allow the great multitude of attributes and resources to be specified
+  # in directories, where the filename is the key and the contents its value.
+  for f in "$etc_slave"/attributes/*
+  do [[ ! -s $f ]] || attributes+=( "$(basename "$f")":"$(cat "$f")" )
+  done
+  if [[ ${#attributes[@]} -gt 0 ]]
+  then
+    local formatted="$(printf ';%s' "${attributes[@]}")"
+    args+=( --attributes="${formatted:1}" )        # NB: Leading ';' is clipped
+  fi
+  for f in "$etc_slave"/resources/*
+  do [[ ! -s $f ]] || resources+=( "$(basename "$f")":"$(cat "$f")" )
+  done
+  if [[ ${#resources[@]} -gt 0 ]]
+  then
+    local formatted="$(printf ';%s' "${resources[@]}")"
+    args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
+  fi
+  ( logged /usr/local/sbin/mesos-slave --master="$MASTER" --recover=cleanup )
   logged /usr/local/sbin/mesos-slave "${args[@]}"
 }
 
 function master {
+  local etc_master=/etc/mesos-master
   local args=()
   [[ ! -f /etc/default/mesos ]]        || . /etc/default/mesos
   [[ ! -f /etc/default/mesos-master ]] || . /etc/default/mesos-master
@@ -35,6 +113,17 @@ function master {
   [[ ! ${PORT:-} ]]    || args+=( --port="$PORT" )
   [[ ! ${CLUSTER:-} ]] || args+=( --cluster="$CLUSTER" )
   [[ ! ${LOGS:-} ]]    || args+=( --log_dir="$LOGS" )
+  for f in "$etc_master"/* # cluster log_dir port &al.
+  do
+    if [[ -f $f ]]
+    then
+      local name="$(basename "$f")"
+      if [[ $name == '?'* ]]         # Recognize flags (options without values)
+      then args+=( --"$name" )
+      else args+=( --"$name"="$(cat "$f")" )
+      fi
+    fi
+  done
   logged /usr/local/sbin/mesos-master "${args[@]}"
 }
 
@@ -54,5 +143,4 @@ if [[ ${1:-} ]] && declare -F | cut -d' ' -f3 | fgrep -qx -- "${1:-}"
 then "$@"
 else main "$@"
 fi
-
 

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -76,7 +76,7 @@ function slave {
     then
       local name="$(basename "$f")"
       if [[ $name == '?'* ]]         # Recognize flags (options without values)
-      then args+=( --"$name" )
+      then args+=( --"${name#'?'}" )
       else args+=( --"$name"="$(cat "$f")" )
       fi
     fi

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -110,6 +110,7 @@ function master {
   [[ ! -f /etc/default/mesos-master ]] || . /etc/default/mesos-master
   [[ ! ${ULIMIT:-} ]]  || ulimit $ULIMIT
   [[ ! ${ZK:-} ]]      || args+=( --zk="$ZK" )
+  [[ ! ${IP:-} ]]      || args+=( --ip="$IP" )
   [[ ! ${PORT:-} ]]    || args+=( --port="$PORT" )
   [[ ! ${CLUSTER:-} ]] || args+=( --cluster="$CLUSTER" )
   [[ ! ${LOGS:-} ]]    || args+=( --log_dir="$LOGS" )

--- a/ubuntu/master.upstart
+++ b/ubuntu/master.upstart
@@ -1,6 +1,10 @@
 description "mesos master"
 
-start on runlevel [2345]
+# Start just after the System-V jobs (rc) to ensure networking and zookeeper
+# are started. This is as simple as possible to ensure compatibility with
+# Ubuntu, Debian, CentOS, and RHEL distros. See:
+# http://upstart.ubuntu.com/cookbook/#standard-idioms
+start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec /usr/bin/mesos-init-wrapper master

--- a/ubuntu/slave.upstart
+++ b/ubuntu/slave.upstart
@@ -1,6 +1,10 @@
 description "mesos slave"
 
-start on runlevel [2345]
+# Start just after the System-V jobs (rc) to ensure networking and zookeeper
+# are started. This is as simple as possible to ensure compatibility with
+# Ubuntu, Debian, CentOS, and RHEL distros. See:
+# http://upstart.ubuntu.com/cookbook/#standard-idioms
+start on stopped rc RUNLEVEL=[2345]
 respawn
 
 exec /usr/bin/mesos-init-wrapper slave


### PR DESCRIPTION
Addresses the issue causing ubuntu/raring, ubuntu/quantal, and debian/wheezy builds to fail.
- Add a function for determining configure options.
- Configure --without-cxx11 for Mesos 0.18.0-rc4. See [MESOS-750](https://issues.apache.org/jira/browse/MESOS-750) and [MESOS-1095](https://issues.apache.org/jira/browse/MESOS-1095) (should be resolved in Mesos core 0.18.0-rc5.)
